### PR TITLE
[fix] ssd_nand.txt 파일 없을떄 read할 경우 error나는 버그 수정

### DIFF
--- a/ssd_controller.py
+++ b/ssd_controller.py
@@ -19,10 +19,11 @@ class SSDController:
             if self.validator.is_lba_bad(addr):
                 self.output(ERROR)
                 return
-
             with open(SSD_NAND_PATH, "r", encoding="utf-8") as f:
                 data = json.load(f).get(str(addr), DEFAULT_VALUE)
                 self.output(data)
+        except FileNotFoundError:
+            self.output(DEFAULT_VALUE)
         except:
             self.output(ERROR)
 
@@ -55,7 +56,8 @@ class SSDController:
     def output(self, data):
         with open(SSD_OUTPUT_PATH, "w", encoding="utf-8") as f:
             f.write(data)
-            
+
+
 def main():
     parser = argparse.ArgumentParser(description="SSD Controller")
     parser.add_argument("mode", choices=["R", "W"], help="모드 선택: R(Read) 또는 W(Write)")


### PR DESCRIPTION
## :pushpin: 주요 변경 사항
-  ssd_nand.txt 파일 없을떄 read할 경우 error나는 버그 수정 

## :page_facing_up: 상세 설명
- FileNotFoundError 에러 처리 반영 

## :test_tube: 테스트 내역
- [ ] 유닛 테스트 작성 여부  
- [ ] Double 사용 여부  
- 테스트 수행 결과 (PASS:100%)