### PR TITLE
[feature] erase, erase_range shell 메소드 개발

### DIFF
--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -177,3 +177,35 @@ def test_shell_fullwrite_valid_check_value_fail(shell_and_subprocess_mocker, val
     with pytest.raises(ValueError):
         shell.fullwrite(f"write {value}")
     assert mock_run.call_count == 0
+
+@pytest.mark.parametrize("value", ["", "3.123", "3 4.1", "3.1 4", "3.123 4.123", "abc", "abc cde", "-2 3"])
+def test_shell_erase_fail(shell_and_subprocess_mocker, value, capsys):
+    shell, mock_run = shell_and_subprocess_mocker
+    with pytest.raises(ValueError):
+        shell.erase(f"erase {value}")
+    assert mock_run.call_count == 0
+
+@pytest.mark.parametrize("value", ["3 5", "3 -1", "3 -2000",])
+def test_shell_erase_success(shell_and_subprocess_mocker, value):
+    shell, mock_run = shell_and_subprocess_mocker
+    shell.erase(f"erase {value}")
+    assert mock_run.call_count == 1
+
+@pytest.mark.parametrize("value", ["2000"])
+def test_shell_erase_success(shell_and_subprocess_mocker, value):
+    shell, mock_run = shell_and_subprocess_mocker
+    shell.erase(f"erase 3 {value}")
+    assert mock_run.call_count == 10
+
+@pytest.mark.parametrize("value", ["", "3.123", "3 4.1", "3.1 4", "3.123 4.123", "abc", "abc cde", "-2 3", "2, -3", "-2 -2"])
+def test_shell_erase_range_fail(shell_and_subprocess_mocker, value):
+    shell, mock_run = shell_and_subprocess_mocker
+    with pytest.raises(ValueError):
+        shell.erase_range(f"erase_range {value}")
+    assert mock_run.call_count == 0
+
+@pytest.mark.parametrize("value", ["3 5", "5 3"])
+def test_shell_erase_range_success(shell_and_subprocess_mocker, value):
+    shell, mock_run = shell_and_subprocess_mocker
+    shell.erase_range(f"erase_range {value}")
+    assert mock_run.call_count == 1


### PR DESCRIPTION
## :pushpin: 주요 변경 사항
- erase 기능 개발
- erase_range 기능 개발
- 두 기능 포맷과 범위 valid test 후에 SSD 의 Erase [lba] [size] 로 넘어가도록 subprocess 개발

## :page_facing_up: 상세 설명
- lba 범위는 반드시 0~99
- size 범위는 int이기만 하면 됨
- SSD Erase로 넘기길 때 start 는 늘 end 보다 작으며, start lba와 end lba 모두 0~99범위가 되도록 size 조절한다.
- SSD Erase로 넘길때 size가 10보다 크면, 10개씩 size쪼개서 전달한다.

## :test_tube: 테스트 내역
- [x] 유닛 테스트 작성 여부  
- [x] Double 사용 여부  
- 테스트 수행 결과 (PASS:100%)