### PR TITLE
Feature/controller cache

### DIFF
--- a/tests/test_controller_cache.py
+++ b/tests/test_controller_cache.py
@@ -1,0 +1,32 @@
+import pytest
+from pytest_mock import mocker
+from core.ssd_controller import SSDController
+
+
+@pytest.fixture
+def successs_buffer():
+    return [
+        {"command": "W", "lba": 0, "size": None, "value": "0xAAAABBBB"},
+        {"command": "W", "lba": 1, "size": None, "value": "0xCCCCDDDD"},
+        {"command": "E", "lba": 2, "size": 10, "value": None},
+        {"command": "W", "lba": 3, "size": None, "value": "0x12345678"},
+        {"command": "E", "lba": 4, "size": 1, "value": None},
+        {"command": "W", "lba": 5, "size": None, "value": "0xDEADBEEF"},
+    ],{0: '0xAAAABBBB',
+          1: '0xCCCCDDDD',
+          2: '0x00000000',
+          3: '0x12345678',
+          4: '0x00000000',
+          5: '0xDEADBEEF',
+          6: '0x00000000',
+          7: '0x00000000',
+          8: '0x00000000',
+          9: '0x00000000',
+          10: '0x00000000',
+          11: '0x00000000'}
+
+def test_update_cache_success(successs_buffer):
+    buffer, expected_cache = successs_buffer
+    ssd = SSDController()
+
+    assert ssd.update_cache(buffer) == expected_cache


### PR DESCRIPTION
## :pushpin: 주요 변경 사항
- buffer의 명령이 반영된 cache메모리 기능을 구현하였습니다.
- update_cache(buffer)후 self.cache로 참조 가능합니다

## :page_facing_up: 상세 설명
- buffer 상태 예제
 [
        {"command": "W", "lba": 0, "size": None, "value": "0xAAAABBBB"},
        {"command": "W", "lba": 1, "size": None, "value": "0xCCCCDDDD"},
        {"command": "E", "lba": 2, "size": 10, "value": None},
        {"command": "W", "lba": 3, "size": None, "value": "0x12345678"},
        {"command": "E", "lba": 4, "size": 1, "value": None},
        {"command": "W", "lba": 5, "size": None, "value": "0xDEADBEEF"},
    ]
- cache 출력 예제
{0: '0xAAAABBBB',
          1: '0xCCCCDDDD',
          2: '0x00000000',
          3: '0x12345678',
          4: '0x00000000',
          5: '0xDEADBEEF',
          6: '0x00000000',
          7: '0x00000000',
          8: '0x00000000',
          9: '0x00000000',
          10: '0x00000000',
          11: '0x00000000'}
## :test_tube: 테스트 내역
- [x] 유닛 테스트 작성 여부  
- [ ] Double 사용 여부  
- 테스트 수행 결과 (PASS:100%)