### PR TITLE
[fix] read/write 및 fullread/fullwrite에서 cache와 nand.txt 동기화 문제 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ ssd_nand.txt
 ssd_output.txt
 build/
 log/
+buffer/

--- a/core/ssd_controller.py
+++ b/core/ssd_controller.py
@@ -173,7 +173,10 @@ class SSDController:
 
     def execute(self, command: Command):
         if command.mode == "R":
-            self.read(command.lba)
+            if command.lba in self.cache.keys():
+                self.output(self.cache[command.lba])
+            else:
+                self.read(command.lba)
         elif command.mode == "W" or command.mode == "E":
             if self.buffer.is_full():
                 self.flush()

--- a/core/ssd_controller.py
+++ b/core/ssd_controller.py
@@ -154,10 +154,12 @@ class SSDController:
         try:
             with open(SSD_NAND_PATH, "r") as f:
                 memory = json.load(f)
-                for i in range(size):
-                    memory[str(addr + i)] = val.lower()
-        except json.decoder.JSONDecodeError:
-            self.ssd_nand_init()
+        except (FileNotFoundError, json.decoder.JSONDecodeError):
+            memory = {}
+
+        for i in range(size):
+            memory[str(addr + i)] = val.lower()
+
         with open(SSD_NAND_PATH, "w") as f:
             json.dump(memory, f)
 


### PR DESCRIPTION
## :pushpin: 주요 변경 사항
- read, write, fullread, fullwrite 함수에서 cache와 nand.txt가 제대로 연동되도록 수정
- nand.txt 읽기 시 JSONDecodeError 발생 시 초기화 처리 추가
- 파일이 없거나 손상된 경우에도 정상 동작하도록 예외 처리 개선
- 캐시 수정 후 항상 nand.txt에 저장되도록 보장

## :page_facing_up: 상세 설명

## :test_tube: 테스트 내역
- [ ] 유닛 테스트 작성 여부  
- [ ] Double 사용 여부  
- 테스트 수행 결과 (PASS:100%)